### PR TITLE
fix: Correct FastAPI endpoint to resolve 422 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ TikTokLive
 fastapi
 uvicorn[standard]
 jinja2
+anyio==3.7.1

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -43,7 +43,7 @@ tiktok_client: TikTokLiveClient = TikTokLiveClient(unique_id=TIKTOK_USERNAME)
 
 # --- FastAPI Routes ---
 @app.get("/", response_class=HTMLResponse)
-async def read_root(request):
+async def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 @app.websocket("/ws")


### PR DESCRIPTION
This commit fixes a bug in the `server.py` file that caused a `422 Unprocessable Entity` error when accessing the root ("/") endpoint.

The error was due to a missing `Request` type hint in the `read_root` function definition. The fix involves:
1. Importing `Request` from the `fastapi` library.
2. Adding the `request: Request` type hint to the function signature.

This ensures that FastAPI correctly processes the request and renders the `index.html` template.