### PR TITLE
feat: Add interactive control panel to UI

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -131,6 +131,28 @@ class Game:
             if self.leaderboard[user_id]['penalized']:
                 self.leaderboard[user_id]['penalized'] = False
 
+    async def set_game_mode(self, mode: str):
+        if mode in self.word_lists:
+            self.game_mode = mode
+            print(f"Game mode changed to: {mode}")
+            # Reset timer for speed up mode if changed to it
+            if self.game_mode == 'speed_up':
+                self.round_time_seconds = self.speed_up_start_time
+            await self.manager.broadcast({
+                "type": "game_mode_changed",
+                "mode": self.game_mode
+            })
+        else:
+            print(f"Attempted to change to invalid game mode: {mode}")
+
+    async def reset_leaderboard(self):
+        self.leaderboard.clear()
+        print("Leaderboard has been reset.")
+        await self.manager.broadcast({
+            "type": "leaderboard_update",
+            "leaderboard": []
+        })
+
     def get_leaderboard_data(self):
         if not self.leaderboard:
             return []

--- a/static/style.css
+++ b/static/style.css
@@ -113,3 +113,51 @@ header h1 {
 .hidden {
     display: none;
 }
+
+#control-panel {
+    background-color: #323232;
+    padding: 15px;
+    border-radius: 8px;
+    margin-bottom: 30px;
+}
+
+#control-panel h2 {
+    margin-top: 0;
+    color: #aaa;
+    font-size: 1.2em;
+}
+
+.control-group {
+    margin: 10px 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 15px;
+}
+
+.control-sub-panel {
+    margin: 15px 0;
+}
+
+#control-panel button {
+    background-color: #64ffda;
+    color: #1a1a1a;
+    border: none;
+    padding: 10px 15px;
+    border-radius: 5px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+#control-panel button:hover {
+    background-color: #52c7b1;
+}
+
+#control-panel select, #control-panel input[type="number"] {
+    background-color: #424242;
+    color: white;
+    border: 1px solid #555;
+    padding: 8px;
+    border-radius: 5px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,20 +12,53 @@
             <p id="status">Connecting to server...</p>
         </header>
 
+        <div id="control-panel">
+            <h2>Control Panel</h2>
+            <div class="control-group">
+                <label for="game-mode-select">Game Mode:</label>
+                <select id="game-mode-select">
+                    <option value="classic">Classic</option>
+                    <option value="hard">Hard</option>
+                    <option value="sentence">Sentence</option>
+                    <option value="emoji">Emoji</option>
+                    <option value="speed_up">Speed Up</option>
+                </select>
+            </div>
+            <div class="control-group">
+                <label>Play Style:</label>
+                <input type="radio" id="mode-manual" name="play_style" value="manual" checked>
+                <label for="mode-manual">Manual</label>
+                <input type="radio" id="mode-auto" name="play_style" value="auto">
+                <label for="mode-auto">Automatic</label>
+            </div>
+
+            <div id="manual-controls" class="control-sub-panel">
+                <button id="start-round-btn">Start Next Round</button>
+            </div>
+
+            <div id="auto-controls" class="control-sub-panel hidden">
+                <label for="auto-delay-input">Delay (s):</label>
+                <input type="number" id="auto-delay-input" value="15" min="5">
+                <button id="toggle-auto-play-btn">Start Auto-Play</button>
+            </div>
+
+            <div class="control-group">
+                 <button id="reset-leaderboard-btn">Reset Leaderboard</button>
+            </div>
+        </div>
+
         <main id="game-view">
             <div id="announcement" class="hidden"></div>
-
             <div id="round-view">
                 <div id="word-to-type-container">
                     <p id="word-label">Type this:</p>
-                    <div id="word-to-type"></div>
+                    <div id="word-to-type">-- Waiting to Start --</div>
                 </div>
                 <div id="timer-container">
                     <p>Time Left</p>
-                    <div id="timer">10</div>
+                    <div id="timer">--</div>
                 </div>
             </div>
-
             <div id="leaderboard-container">
                 <h2>Leaderboard</h2>
                 <table id="leaderboard">


### PR DESCRIPTION
I've added a full-featured control panel to the web UI, allowing you to dynamically control the game during a livestream.

Key features of the control panel:
- Game Mode Selection: A dropdown to change the game mode (Classic, Hard, etc.) on the fly.
- Manual Round Control: A "Start Next Round" button for manual pacing of the game.
- Automatic Round Control: A "Start/Stop Auto-Play" button with an adjustable delay to run the game automatically.
- Leaderboard Reset: A button to clear all scores and start a new game session.

This change enhances the backend and frontend:
- `server.py` has been updated to handle commands from the UI via WebSockets, managing the game state and auto-play loop.
- `game_logic.py` has new methods to support these actions.
- `index.html` and `script.js` have been updated to build and power the interactive control panel.

The game is no longer fully automatic on startup and now requires your interaction through the UI to begin, giving you full control.