### PR TITLE
fix: Resolve 'TikTokLive is not defined' error in websocket

### DIFF
--- a/server.py
+++ b/server.py
@@ -72,12 +72,10 @@ async def websocket_endpoint(websocket: WebSocket):
                     await manager.broadcast({"type": "status_update", "message": f"Connecting to {game_settings['username']}..."})
 
                     # Define handlers here to close over the current game and manager instances
-                    @TikTokLive.on(ConnectEvent)
                     async def on_connect(event: ConnectEvent):
                         print(f"Successfully connected to @{event.unique_id}")
                         await manager.broadcast({"type": "tiktok_connected"})
 
-                    @TikTokLive.on(CommentEvent)
                     async def on_comment(event: CommentEvent):
                         await game.check_answer(user_id=event.user.unique_id, nickname=event.user.nickname, comment=event.comment)
 


### PR DESCRIPTION
This commit fixes a `NameError` that occurred when trying to connect to TikTok via the UI. The error was caused by incorrectly using `@TikTokLive.on()` decorators on event handler functions that were defined inside the WebSocket endpoint.

The decorator syntax is not valid in this context because the TikTok client instance is created dynamically. The fix removes these redundant and incorrect decorators. The event handlers are already correctly registered using the `tiktok_client.add_listener()` method, so the functionality remains the same.