### PR TITLE
fix: Remove incorrect 'User' import from server

### DIFF
--- a/server.py
+++ b/server.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Dict, Any
 
 # Import the base TikTok client
 from TikTokLive import TikTokLiveClient
-from TikTokLive.events import CommentEvent, ConnectEvent, User
+from TikTokLive.events import CommentEvent, ConnectEvent
 
 # Try to import API keys from config.py
 try:


### PR DESCRIPTION
This commit fixes an `ImportError: cannot import name 'User'` that caused the server to fail on startup.

The error was due to an incorrect and unused import of a `User` class from `TikTokLive.events`. This class does not exist at that location. The fix removes the `User` from the import statement.